### PR TITLE
Remember monitored channel names in config

### DIFF
--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -36,16 +36,14 @@
     {
         public string nickname, cmdr, platform, langcode;  // The nickname to monitor
         public int retries = 0;
-        public IWindow window;   // The window to output translated messages into.
 
-        public monitorItem(string nickname, string cmdr, IWindow window, string langcode = "EN", string platform = "")
+        public monitorItem(string nickname, string cmdr, string langcode = "EN", string platform = "")
         {
             //A case object, keeping track of a client's nick, cmdr, platform, and channel window
             this.nickname = nickname;
             this.cmdr = cmdr;
             this.langcode = langcode;
             this.platform = platform; //for future use, maybe
-            this.window = window;
         }
     }
     public class deepl_config_items
@@ -263,7 +261,7 @@
         private void deepl_mon(RegisteredCommandArgs argument)
         {
             string allarguments = argument.Command.Substring(argument.Command.IndexOf(" ") + 1);
-            monitorItem monitorCandidate = new monitorItem(allarguments, allarguments, argument.Window, langcode: "ZZ");
+            monitorItem monitorCandidate = new monitorItem(allarguments, allarguments, langcode: "ZZ");
 
             if (!IsNickMonitored(allarguments))
                 monitor_items.Add(monitorCandidate); //add new entry into 20+ zone (ideally non-cases)
@@ -411,7 +409,7 @@
             int index = 0;
             foreach (monitorItem item in monitor_items)
             {
-                if (item != null) adihost.ActiveIWindow.OutputText(String.Format("#{0} - Nick: {1}, Lang: {2}, Channel: {3}", index, item.nickname, item.langcode, item.window.Name));
+                if (item != null) adihost.ActiveIWindow.OutputText(String.Format("#{0} - Nick: {1}, Lang: {2}", index, item.nickname, item.langcode));
                 index++;
             }
             foreach (string channelName in config_items.channel_monitor_items)
@@ -495,12 +493,12 @@
                                 if (match.Groups["nickname"].Success)
                                 {
                                     string nick = match.Groups["nickname"].Value;
-                                    monitor_items[caseNum] = new monitorItem(nick, cmdr, channel, langcode: langcode);
+                                    monitor_items[caseNum] = new monitorItem(nick, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + nick);
                                 }
                                 else
                                 {
-                                    monitor_items[caseNum] = new monitorItem(cmdr, cmdr, channel, langcode: langcode);
+                                    monitor_items[caseNum] = new monitorItem(cmdr, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + cmdr);
                                 }
                             }

--- a/TestClasses.cs
+++ b/TestClasses.cs
@@ -37,6 +37,15 @@ namespace adiIRC_DeepL_plugin_test
         }
     }
 
+    public class IServer
+    {
+        public List<IChannel> Channels;
+        public IServer(List<IChannel> channels)
+        {
+            Channels = channels;
+        }
+    }
+
     public class IChannel : IWindow
     {
         public static string windowName;
@@ -60,10 +69,12 @@ namespace adiIRC_DeepL_plugin_test
 
         public IWindow ActiveIWindow;
         public string ConfigFolder;
-        public IPluginHost(IWindow activeIWindow, string configFolder)
+        public List<IServer> GetServers;
+        public IPluginHost(IWindow activeIWindow, string configFolder, List<IServer> getServers)
         {
             ActiveIWindow = activeIWindow;
             ConfigFolder = configFolder;
+            GetServers = getServers;
         }
     }
 

--- a/TestDriver.cs
+++ b/TestDriver.cs
@@ -19,9 +19,18 @@ namespace adiIRC_DeepL_plugin_test
         public static async Task Main(string[] args)
         {
             adiIRC_DeepL_plugin testPlugin = new adiIRC_DeepL_plugin();
+
+            // Set up channel
             IChannel fuelratsChan = new IChannel();
             fuelratsChan.Name = "#fuelrats";
-            IPluginHost pluginHost = new IPluginHost(fuelratsChan, ".\\");
+            List<IChannel> fuelratsChannelList = new List<IChannel>();
+            fuelratsChannelList.Add(fuelratsChan);
+
+            // Set up server
+            IServer fuelratsServer = new IServer(fuelratsChannelList);
+            List<IServer> fuelratsServerList = new List<IServer>();
+            fuelratsServerList.Add(fuelratsServer);
+            IPluginHost pluginHost = new IPluginHost(fuelratsChan, ".\\", fuelratsServerList);
             testPlugin.Initialize(pluginHost);
 
             //If API key is not saved, prompt user for key
@@ -32,7 +41,7 @@ namespace adiIRC_DeepL_plugin_test
             }
 
             bool testResult = false;
-            bool testAPI = true; // flip this switch to test API calls, keep off to save API usage
+            bool testAPI = false; // flip this switch to test API calls, keep off to save API usage
 
             // Test enabling debugmode
             testPlugin.deepl_set(new RegisteredCommandArgs("debugmode", fuelratsChan));

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -40,16 +40,14 @@ namespace adiIRC_DeepL_plugin_test
     {
         public string nickname, cmdr, platform, langcode;  // The nickname to monitor
         public int retries = 0;
-        public IWindow window;   // The window to output translated messages into.
 
-        public monitorItem(string nickname, string cmdr, IWindow window, string langcode = "EN", string platform = "")
+        public monitorItem(string nickname, string cmdr, string langcode = "EN", string platform = "")
         {
             //A case object, keeping track of a client's nick, cmdr, platform, and channel window
             this.nickname = nickname;
             this.cmdr = cmdr;
             this.langcode = langcode;
             this.platform = platform; //for future use, maybe
-            this.window = window;
         }
     }
     public class deepl_config_items
@@ -271,7 +269,7 @@ namespace adiIRC_DeepL_plugin_test
         public void deepl_mon(RegisteredCommandArgs argument)
         {
             string allarguments = argument.Command.Substring(argument.Command.IndexOf(" ") + 1);
-            monitorItem monitorCandidate = new monitorItem(allarguments, allarguments, argument.Window, langcode: "ZZ");
+            monitorItem monitorCandidate = new monitorItem(allarguments, allarguments, langcode: "ZZ");
 
             if (!IsNickMonitored(allarguments))
                 monitor_items.Add(monitorCandidate); //add new entry into 20+ zone (ideally non-cases)
@@ -419,7 +417,7 @@ namespace adiIRC_DeepL_plugin_test
             int index = 0;
             foreach (monitorItem item in monitor_items)
             {
-                if (item != null) adihost.ActiveIWindow.OutputText(String.Format("#{0} - Nick: {1}, Lang: {2}, Channel: {3}", index, item.nickname, item.langcode, item.window.Name));
+                if (item != null) adihost.ActiveIWindow.OutputText(String.Format("#{0} - Nick: {1}, Lang: {2}", index, item.nickname, item.langcode));
                 index++;
             }
             foreach (string channelName in config_items.channel_monitor_items)
@@ -503,12 +501,12 @@ namespace adiIRC_DeepL_plugin_test
                                 if (match.Groups["nickname"].Success)
                                 {
                                     string nick = match.Groups["nickname"].Value;
-                                    monitor_items[caseNum] = new monitorItem(nick, cmdr, channel, langcode: langcode);
+                                    monitor_items[caseNum] = new monitorItem(nick, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + nick);
                                 }
                                 else
                                 {
-                                    monitor_items[caseNum] = new monitorItem(cmdr, cmdr, channel, langcode: langcode);
+                                    monitor_items[caseNum] = new monitorItem(cmdr, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + cmdr);
                                 }
                             }


### PR DESCRIPTION
Instead of storing IChannel objects in channel_monitor_items, this changes it to just store channel names as strings. This way the monitored channels can be easily written to the config file, and remembered after an Adi relaunch.