### PR TITLE
Small fixes, and Native Language change support

### DIFF
--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -456,13 +456,28 @@
                 if (item != null) adihost.ActiveIWindow.OutputText(String.Format("#{0} - Nick: {1}, Lang: {2}", index, item.nickname, item.langcode));
                 index++;
             }
+
+            string monitoredChannels = "";
             foreach (string channelName in config_items.channel_monitor_items)
             {
-                adihost.ActiveIWindow.OutputText("Monitored Channel: " + channelName);
+                monitoredChannels += channelName + ", ";
             }
+            monitoredChannels = monitoredChannels.TrimEnd(' ', ',');
+
+            string excludedLangs = "";
+            foreach (string lang in config_items.lang_no_translation)
+            {
+                excludedLangs += lang + ", ";
+            }
+            excludedLangs = excludedLangs.TrimEnd(' ', ',');
+
+            adihost.ActiveIWindow.OutputText("Native Language: " + config_items.native_lang);
+            adihost.ActiveIWindow.OutputText("Monitored Channels: " + monitoredChannels);
+            adihost.ActiveIWindow.OutputText("Excluded Languages: " + excludedLangs);
             adihost.ActiveIWindow.OutputText("AutoRemoveNick: " + config_items.removePartingNicknames);
             adihost.ActiveIWindow.OutputText("ReverseTranslate: " + reverseTranslate);
             adihost.ActiveIWindow.OutputText("Drillmode: " + drillmode);
+            adihost.ActiveIWindow.OutputText("Debugmode: " + debugmode);
         }
 
         private void deepl_help(RegisteredCommandArgs argument)

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -520,11 +520,22 @@
                                 if (match.Groups["nickname"].Success)
                                 {
                                     string nick = match.Groups["nickname"].Value;
+
+                                    // check if repeat client
+                                    int index;
+                                    if (IsNickMonitored(nick, out index))
+                                        monitor_items[index] = null;
+
                                     monitor_items[caseNum] = new monitorItem(nick, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + nick);
                                 }
                                 else
                                 {
+                                    // check if repeat client
+                                    int index;
+                                    if (IsNickMonitored(cmdr, out index))
+                                        monitor_items[index] = null;
+
                                     monitor_items[caseNum] = new monitorItem(cmdr, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + cmdr);
                                 }

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -267,13 +267,17 @@
             string lang = allarguments.Substring(0, 2).ToUpper();
             string totranslate = allarguments.Substring(3);
             deepl_translation translation = await deepl_translate(lang, totranslate);
-            argument.Window.Editbox.Text = translation.text;
 
-            deepl_translation reverseTranslation = null;
-            if (reverseTranslate)
-            {
-                reverseTranslation = await deepl_translate("EN", translation.text, lang);
-                argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
+            if (translation != null)
+            {  //translation failure
+                argument.Window.Editbox.Text = translation.text;
+
+                deepl_translation reverseTranslation = null;
+                if (reverseTranslate)
+                {
+                    reverseTranslation = await deepl_translate("EN", translation.text, lang);
+                    argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
+                }
             }
         }
 
@@ -541,7 +545,7 @@
                     if (!langcode.Equals("EN") && !config_items.lang_no_translation.Contains(langcode))
                     {
                         PrintDebug("Translating {0}'s message - {1}", message.User.Nick, message.Message);
-                        deepl_translate_towindow("EN", message.Message, channel, message.User.Nick);
+                        deepl_translate_towindow("EN", message.Message, channel, monitor_items[index]);
                     }
                 }
             }

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -439,7 +439,7 @@
                 debugmode = !debugmode;
 
                 // print drillmode state after switch
-                if (drillmode) adihost.ActiveIWindow.OutputText("DebugMode™ Enabled!");
+                if (debugmode) adihost.ActiveIWindow.OutputText("DebugMode™ Enabled!");
                 else adihost.ActiveIWindow.OutputText("DebugMode™ Disabled.");
             }
         }

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -369,7 +369,8 @@
         private void deepl_set(RegisteredCommandArgs argument)
         {
             string[] allarguments = argument.Command.Split(' ');
-            if (allarguments[0].Equals("autoRemoveNicks"))
+            
+            if (allarguments[1].Equals("autoRemoveNicks"))
             {
                 config_items.removePartingNicknames = !config_items.removePartingNicknames;
                 // print drillmode state after switch
@@ -379,7 +380,7 @@
                 save_config_items();
             }
 
-            if (allarguments[0].Equals("reverseTranslate"))
+            if (allarguments[1].Equals("reverseTranslate"))
             {
                 reverseTranslate = !reverseTranslate;
                 // print drillmode state after switch
@@ -389,11 +390,11 @@
                 save_config_items();
             }
 
-            if (allarguments[0].Equals("native"))
+            if (allarguments[1].Equals("native"))
             {
-                if (allarguments.Length > 1)
+                if (allarguments.Length > 2)
                 {
-                    string langcode = allarguments[1].ToUpper();
+                    string langcode = allarguments[2].ToUpper();
                     config_items.native_lang = langcode;
                     save_config_items();
                 }
@@ -401,22 +402,28 @@
                     adihost.ActiveIWindow.OutputText("Error: 'native' setting requires language code argument");
             }
 
-            if (allarguments[0].Equals("exclude"))
+            if (allarguments[1].Equals("exclude"))
             {
-                if (allarguments.Length > 1)
+                if (allarguments.Length > 2)
                 {
-                    string langcode = allarguments[1].ToUpper();
+                    string langcode = allarguments[2].ToUpper();
                     if (!config_items.lang_no_translation.Contains(langcode))
                     {
                         config_items.lang_no_translation.Add(langcode);
-                        save_config_items();
+                        adihost.ActiveIWindow.OutputText(String.Format("Langcode '{0}' added to exclude list.", langcode));
                     }
+                    else
+                    {
+                        config_items.lang_no_translation.Remove(langcode);
+                        adihost.ActiveIWindow.OutputText(String.Format("Langcode '{0}' removed from exclude list.", langcode));
+                    }
+                    save_config_items();
                 }
                 else
                     adihost.ActiveIWindow.OutputText("Error: 'exclude' setting requires language code argument");
             }
 
-            if (allarguments[0].Equals("drillmode"))
+            if (allarguments[1].Equals("drillmode"))
             {
                 // this config should only be in memory, not saved to deepl.conf
                 drillmode = !drillmode;
@@ -426,7 +433,7 @@
                 else adihost.ActiveIWindow.OutputText("DrillMode™ Disabled.");
             }
 
-            if (allarguments[0].Equals("debugmode"))
+            if (allarguments[1].Equals("debugmode"))
             {
                 // this config should only be in memory, not saved to deepl.conf
                 debugmode = !debugmode;
@@ -469,7 +476,7 @@
             adihost.ActiveIWindow.OutputText("/dl-mecha - Starts monitoring for Fuel Rats cases announced by MechaSqueak in the active channel");
             adihost.ActiveIWindow.OutputText("/dl-clear - Clears the list of nicks to monitor for translations. Also disables case monitoring");
             adihost.ActiveIWindow.OutputText("/dl-set <option> - Configures certain behavious of the plugin");
-            adihost.ActiveIWindow.OutputText("  exclude <langcode>  -> (config) add language to list that should not be auto-translated");
+            adihost.ActiveIWindow.OutputText("  exclude <langcode>  -> (config) add/remove language on list that should not be auto-translated");
             adihost.ActiveIWindow.OutputText("  native <langcode>   -> (config) change native langauge (default: EN)");
             adihost.ActiveIWindow.OutputText("  autoRemoveNicks     -> (config) toggles auto removal of non-case nicks on parts or quits");
             adihost.ActiveIWindow.OutputText("  reverseTranslate    -> (memory) toggles a reverse translation of /dl-any");

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -521,21 +521,11 @@
                                 {
                                     string nick = match.Groups["nickname"].Value;
 
-                                    // check if repeat client
-                                    int index;
-                                    if (IsNickMonitored(nick, out index))
-                                        monitor_items[index] = null;
-
                                     monitor_items[caseNum] = new monitorItem(nick, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + nick);
                                 }
                                 else
                                 {
-                                    // check if repeat client
-                                    int index;
-                                    if (IsNickMonitored(cmdr, out index))
-                                        monitor_items[index] = null;
-
                                     monitor_items[caseNum] = new monitorItem(cmdr, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + cmdr);
                                 }

--- a/AdiIRCPlugin.csproj
+++ b/AdiIRCPlugin.csproj
@@ -12,6 +12,21 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,6 +45,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AdiIRCAPIv2">
       <HintPath>.\AdiIRCAPIv2.dll</HintPath>
@@ -38,20 +56,30 @@
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestClasses.cs" />
+    <Compile Include="TestDriver.cs" />
+    <Compile Include="TestPlugin.cs" />
     <Compile Include="AdiIRCPlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AdiIRCPlugin.csproj.user
+++ b/AdiIRCPlugin.csproj.user
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishUrlHistory>publish\</PublishUrlHistory>
+    <InstallUrlHistory />
+    <SupportUrlHistory />
+    <UpdateUrlHistory />
+    <BootstrapperUrlHistory />
+    <ErrorReportUrlHistory />
+    <FallbackCulture>en-US</FallbackCulture>
+    <VerifyUploadedFiles>false</VerifyUploadedFiles>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Example usage:
 
 Use this command to toggle various options. Options labeled as "(config)" will be written to the deepl.conf file and remembered between Adi client. Options labeled as "(memory)" will be forgotten between Adi client restarts.
 
-- exclude <langcode> (config): For multi-lingual users, this will disable auto-translation for additional languages.
+- exclude <langcode> (config): For multi-lingual users, this will disable auto-translation for additional languages. Run this again to remove a language from the exclude list.
 - native <langcode> (config): Change native language from default English to another language.
 - autoRemoveNicks (config): When a monitored client leaves IRC, this will automatically remove them from monitoring. This does not apply to Fuel Rat case clients, monitored by /dl-mecha.
 - reverseTranslate (memory): When using /dl-any, this will additionally take the resulting translation, and feed it back to DeepL to translate the message back into English. The reverse translated English message will be printed to the Output Window. This can be useful when trying to communicate nuanced information, and helps the user check if their message was translated properly. Warning: This will increase translation character usage of the Free DeepL Account API.

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Incoming cases and their language can be automatically identified and marked for
 # Usage
 
 --  
-**/dl-debug**
+**/dl-help**
 ```
-/dl-debug
+/dl-help
 Args:
  - None
 Example usage:
-/dl-debug
+/dl-help
 ```
 
 Prints man page.
@@ -70,7 +70,7 @@ Example usage:
 /dl-en Il s'agit d'un test.
 ```
 
-This will translate a message from any DeepL supported language to English, and print the resulting translation to the output window.
+This will translate a message from any DeepL supported language to user's native language, and print the resulting translation to the output window.
 
 --  
 **/dl-any**
@@ -83,7 +83,7 @@ Example usage:
 /dl-any FR This is a test
 ```
 
-Translates any language into a target language. Usually this will be your native language into a non-native language. "/dl-set reverseTranslate" can be used to enable this function to translate the resulting message back into English for inspection purposes.
+Translates any language into a target language. Usually this will be your native language into a non-native language. "/dl-set reverseTranslate" can be used to enable this function to translate the resulting message back into user's native language for inspection purposes.
 
 --  
 **/dl-mon**
@@ -136,33 +136,25 @@ Example usage:
 Clears all currently monitored users and channels.
 
 --  
-**/dl-exclude**
-```
-/dl-exclude <langcode>
-Args:
- - langcode: Two letter language code to NOT translate
-Example usage:
-/dl-exclude DE
-```
-
-Currently only for Fuel Rats use with autodetected cases. If you speak languages other than English, use this command to disable automatic translation for those languages.
-
---  
 **/dl-set**
 ```
 /dl-rm <option>
 Options:
+  exclude <langcode>  -> (config) add language to list that should not be auto-translated
+  native <langcode>   -> (config) change native langauge (default: EN)
   autoRemoveNicks  -> (config) toggles auto removal of non-case nicks when nick parts or quits
   reverseTranslate -> (memory) toggles a reverse translation of /dl-any
   drillmode        -> (memory) toggles whether to observe MechaSqueak or DrillSqueak
   debugmode        -> (memory) toggles extra debug messages during operations
 Example usage:
-/dl-set reverseTranslate
+/dl-set native DE
 /dl-set autoRemoveNicks
 ```
 
 Use this command to toggle various options. Options labeled as "(config)" will be written to the deepl.conf file and remembered between Adi client. Options labeled as "(memory)" will be forgotten between Adi client restarts.
 
+- exclude <langcode> (config): For multi-lingual users, this will disable auto-translation for additional languages.
+- native <langcode> (config): Change native language from default English to another language.
 - autoRemoveNicks (config): When a monitored client leaves IRC, this will automatically remove them from monitoring. This does not apply to Fuel Rat case clients, monitored by /dl-mecha.
 - reverseTranslate (memory): When using /dl-any, this will additionally take the resulting translation, and feed it back to DeepL to translate the message back into English. The reverse translated English message will be printed to the Output Window. This can be useful when trying to communicate nuanced information, and helps the user check if their message was translated properly. Warning: This will increase translation character usage of the Free DeepL Account API.
 - drillmode (memory): Fuel Rat Usage. Changes the plugin to monitor DrillSqueak instead of MechaSqueak. Used primarily for testing the plugin.

--- a/TestDriver.cs
+++ b/TestDriver.cs
@@ -42,10 +42,10 @@ namespace adiIRC_DeepL_plugin_test
 
             bool testResult = false;
             bool testAPI = true; // flip this switch to test API calls, keep off to save API usage
-            testPlugin.deepl_set(new RegisteredCommandArgs("native EN", fuelratsChan));
+            testPlugin.deepl_set(new RegisteredCommandArgs("_ native EN", fuelratsChan));
 
             // Test enabling debugmode
-            testPlugin.deepl_set(new RegisteredCommandArgs("debugmode", fuelratsChan));
+            testPlugin.deepl_set(new RegisteredCommandArgs("_ debugmode", fuelratsChan));
             if (adiIRC_DeepL_plugin.debugmode) testResult = true;
             else testResult = false;
             PrintTestResult("Enable Debug Mode", testResult);
@@ -210,13 +210,13 @@ namespace adiIRC_DeepL_plugin_test
             if (testAPI)
             {
                 Console.WriteLine("\n==== Reverse Translation ====");
-                if (!adiIRC_DeepL_plugin.reverseTranslate) testPlugin.deepl_set(new RegisteredCommandArgs("reverseTranslate", fuelratsChan));
+                if (!adiIRC_DeepL_plugin.reverseTranslate) testPlugin.deepl_set(new RegisteredCommandArgs("_ reverseTranslate", fuelratsChan));
                 string translation = await testPlugin.deepl_any(new RegisteredCommandArgs("_ FR This is a test.", fuelratsChan));
                 if (translation.Equals("Il s'agit d'un test.|This is a test.")) testResult = true;
                 else testResult = false;
                 PrintTestResult("Reverse Translation", testResult);
 
-                testPlugin.deepl_set(new RegisteredCommandArgs("reverseTranslate", fuelratsChan)); //turn off again
+                testPlugin.deepl_set(new RegisteredCommandArgs("_ reverseTranslate", fuelratsChan)); //turn off again
             }
 
 
@@ -224,7 +224,7 @@ namespace adiIRC_DeepL_plugin_test
             if (testAPI)
             {
                 Console.WriteLine("\n==== Native Language Change ====");
-                testPlugin.deepl_set(new RegisteredCommandArgs("native DE", fuelratsChan));
+                testPlugin.deepl_set(new RegisteredCommandArgs("_ native DE", fuelratsChan));
                 string translation = await testPlugin.deepl_en(new RegisteredCommandArgs("_ This is a test.", fuelratsChan));
                 if (translation.Equals("Yourself(EN): Dies ist ein Test.")) testResult = true;
                 else testResult = false;

--- a/TestDriver.cs
+++ b/TestDriver.cs
@@ -42,6 +42,7 @@ namespace adiIRC_DeepL_plugin_test
 
             bool testResult = false;
             bool testAPI = true; // flip this switch to test API calls, keep off to save API usage
+            testPlugin.deepl_set(new RegisteredCommandArgs("native EN", fuelratsChan));
 
             // Test enabling debugmode
             testPlugin.deepl_set(new RegisteredCommandArgs("debugmode", fuelratsChan));
@@ -214,6 +215,21 @@ namespace adiIRC_DeepL_plugin_test
                 if (translation.Equals("Il s'agit d'un test.|This is a test.")) testResult = true;
                 else testResult = false;
                 PrintTestResult("Reverse Translation", testResult);
+
+                testPlugin.deepl_set(new RegisteredCommandArgs("reverseTranslate", fuelratsChan)); //turn off again
+            }
+
+
+            // Test Native Lang Change
+            if (testAPI)
+            {
+                Console.WriteLine("\n==== Native Language Change ====");
+                testPlugin.deepl_set(new RegisteredCommandArgs("native DE", fuelratsChan));
+                string translation = await testPlugin.deepl_en(new RegisteredCommandArgs("_ This is a test.", fuelratsChan));
+                if (translation.Equals("Yourself(EN): Dies ist ein Test.")) testResult = true;
+                else testResult = false;
+                PrintTestResult("Native Language Change", testResult);
+
             }
 
 

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -257,10 +257,10 @@ namespace adiIRC_DeepL_plugin_test
         /// Translates any language into English
         /// </summary>
         /// <param name="argument">Message to translate</param>
-        public void deepl_en(RegisteredCommandArgs argument)
+        public async void deepl_en(RegisteredCommandArgs argument)
         {
             string allarguments = argument.Command.Substring(argument.Command.IndexOf(" ") + 1);
-            deepl_translate_towindow("EN", allarguments, argument.Window, new monitorItem("Yourself", "Yourself", NO_LANG));
+            await deepl_translate_towindow("EN", allarguments, argument.Window, new monitorItem("Yourself", "Yourself", NO_LANG));
         }
 
         /// <summary>
@@ -274,20 +274,22 @@ namespace adiIRC_DeepL_plugin_test
             string totranslate = allarguments.Substring(3);
             deepl_translation translation = await deepl_translate(lang, totranslate);
 
-            if (translation == null) return ""; //translation failure
+            if (translation == null)
+            {  //translation failure
 
-            argument.Window.Editbox.Text = translation.text;
+                argument.Window.Editbox.Text = translation.text;
 
-            deepl_translation reverseTranslation = null;
-            if (reverseTranslate)
-            {
-                reverseTranslation = await deepl_translate("EN", translation.text, lang);
-                argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
+                deepl_translation reverseTranslation = null;
+                if (reverseTranslate)
+                {
+                    reverseTranslation = await deepl_translate("EN", translation.text, lang);
+                    argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
+                }
+
+                // return type changd for debug and unit test purposes
+                if (reverseTranslate && reverseTranslation != null)
+                    return translation.text + "|" + reverseTranslation.text;
             }
-
-            // return type changd for debug and unit test purposes
-            if (reverseTranslate && reverseTranslation != null)
-                return translation.text + "|" + reverseTranslation.text;
             return translation.text;
         }
 

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -384,7 +384,7 @@ namespace adiIRC_DeepL_plugin_test
         public void deepl_set(RegisteredCommandArgs argument)
         {
             string[] allarguments = argument.Command.Split(' ');
-            if (allarguments[0].Equals("autoRemoveNicks"))
+            if (allarguments[1].Equals("autoRemoveNicks"))
             {
                 config_items.removePartingNicknames = !config_items.removePartingNicknames;
                 // print drillmode state after switch
@@ -394,7 +394,7 @@ namespace adiIRC_DeepL_plugin_test
                 save_config_items();
             }
 
-            if (allarguments[0].Equals("reverseTranslate"))
+            if (allarguments[1].Equals("reverseTranslate"))
             {
                 reverseTranslate = !reverseTranslate;
                 // print drillmode state after switch
@@ -404,11 +404,11 @@ namespace adiIRC_DeepL_plugin_test
                 save_config_items();
             }
 
-            if (allarguments[0].Equals("native"))
+            if (allarguments[1].Equals("native"))
             {
-                if (allarguments.Length > 1)
+                if (allarguments.Length > 2)
                 {
-                    string langcode = allarguments[1].ToUpper();
+                    string langcode = allarguments[2].ToUpper();
                     config_items.native_lang = langcode;
                     save_config_items();
                 }
@@ -416,22 +416,28 @@ namespace adiIRC_DeepL_plugin_test
                     adihost.ActiveIWindow.OutputText("Error: 'native' setting requires language code argument");
             }
 
-            if (allarguments[0].Equals("exclude"))
+            if (allarguments[1].Equals("exclude"))
             {
-                if (allarguments.Length > 1)
+                if (allarguments.Length > 2)
                 {
-                    string langcode = allarguments[1].ToUpper();
+                    string langcode = allarguments[2].ToUpper();
                     if (!config_items.lang_no_translation.Contains(langcode))
                     {
                         config_items.lang_no_translation.Add(langcode);
-                        save_config_items();
+                        adihost.ActiveIWindow.OutputText(String.Format("Langcode '{0}' added to exclude list.", langcode));
                     }
+                    else
+                    {
+                        config_items.lang_no_translation.Remove(langcode);
+                        adihost.ActiveIWindow.OutputText(String.Format("Langcode '{0}' removed from exclude list.", langcode));
+                    }
+                    save_config_items();
                 }
                 else
                     adihost.ActiveIWindow.OutputText("Error: 'exclude' setting requires language code argument");
             }
 
-            if (allarguments[0].Equals("drillmode"))
+            if (allarguments[1].Equals("drillmode"))
             {
                 // this config should only be in memory, not saved to deepl.conf
                 drillmode = !drillmode;
@@ -441,7 +447,7 @@ namespace adiIRC_DeepL_plugin_test
                 else adihost.ActiveIWindow.OutputText("DrillMode™ Disabled.");
             }
 
-            if (allarguments[0].Equals("debugmode"))
+            if (allarguments[1].Equals("debugmode"))
             {
                 // this config should only be in memory, not saved to deepl.conf
                 debugmode = !debugmode;
@@ -479,18 +485,18 @@ namespace adiIRC_DeepL_plugin_test
             adihost.ActiveIWindow.OutputText("/dl-api <api-key> - Sets your DeepL Api key. https://www.deepl.com/en/signup/?cta=checkout");
             adihost.ActiveIWindow.OutputText("/dl-en <text> - Translates text to english");
             adihost.ActiveIWindow.OutputText("/dl-any <langcode> <text> - Translates text to target language and places translation into active editbox");
-            adihost.ActiveIWindow.OutputText("/dl-mon <nickname> - Translates every message made by <nickname> to english");
-            adihost.ActiveIWindow.OutputText("/dl-rm <nickname>|<caseNumber> - Removes a single nickname or case number from the monitor list.");
-            adihost.ActiveIWindow.OutputText("/dl-mecha - Identifies fuelrat cases announced by MechaSqueak in the active channel and add them to the monitor list");
-            adihost.ActiveIWindow.OutputText("/dl-clear - Clears the list of nicks to monitor for translations. Also disables case monitoring.");
-            adihost.ActiveIWindow.OutputText("/dl-set <option> - Configures certain behavious of the plugin.");
-            adihost.ActiveIWindow.OutputText("     exclude <langcode>  -> (config) add language to list of languages that should not be auto-translated");
-            adihost.ActiveIWindow.OutputText("     native <langcode>   -> (config) change native langauge (default: EN)");
-            adihost.ActiveIWindow.OutputText("     autoRemoveNicks     -> (config) toggles auto removal of non-case nicks when nick parts or quits");
-            adihost.ActiveIWindow.OutputText("     reverseTranslate    -> (memory) toggles a reverse translation of /dl-any");
-            adihost.ActiveIWindow.OutputText("     drillmode           -> (memory) toggles whether to observe MechaSqueak or DrillSqueak");
-            adihost.ActiveIWindow.OutputText("     debugmode           -> (memory) toggles extra debug messages during operations");
-            adihost.ActiveIWindow.OutputText("/dl-debug - Lists items monitored and/or other plugin debug information");
+            adihost.ActiveIWindow.OutputText("/dl-mon <nickname> - Translates every message made by <nickname> to your native language");
+            adihost.ActiveIWindow.OutputText("/dl-rm <nickname>|<caseNumber> - Removes a single nickname or case number from the monitor list");
+            adihost.ActiveIWindow.OutputText("/dl-mecha - Starts monitoring for Fuel Rats cases announced by MechaSqueak in the active channel");
+            adihost.ActiveIWindow.OutputText("/dl-clear - Clears the list of nicks to monitor for translations. Also disables case monitoring");
+            adihost.ActiveIWindow.OutputText("/dl-set <option> - Configures certain behavious of the plugin");
+            adihost.ActiveIWindow.OutputText("  exclude <langcode>  -> (config) add/remove language on list that should not be auto-translated");
+            adihost.ActiveIWindow.OutputText("  native <langcode>   -> (config) change native langauge (default: EN)");
+            adihost.ActiveIWindow.OutputText("  autoRemoveNicks     -> (config) toggles auto removal of non-case nicks on parts or quits");
+            adihost.ActiveIWindow.OutputText("  reverseTranslate    -> (memory) toggles a reverse translation of /dl-any");
+            adihost.ActiveIWindow.OutputText("  drillmode           -> (memory) toggles whether to observe MechaSqueak or DrillSqueak");
+            adihost.ActiveIWindow.OutputText("  debugmode           -> (memory) toggles extra debug messages during operations");
+            adihost.ActiveIWindow.OutputText("/dl-debug - Lists items monitored and other plugin debug information");
             adihost.ActiveIWindow.OutputText("/dl-help - Shows this command reference");
         }
 

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -453,7 +453,7 @@ namespace adiIRC_DeepL_plugin_test
                 debugmode = !debugmode;
 
                 // print drillmode state after switch
-                if (drillmode) adihost.ActiveIWindow.OutputText("DebugMode™ Enabled!");
+                if (debugmode) adihost.ActiveIWindow.OutputText("DebugMode™ Enabled!");
                 else adihost.ActiveIWindow.OutputText("DebugMode™ Disabled.");
             }
         }

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -275,7 +275,7 @@ namespace adiIRC_DeepL_plugin_test
             string totranslate = allarguments.Substring(3);
             deepl_translation translation = await deepl_translate(lang, totranslate);
 
-            if (translation == null)
+            if (translation != null)
             {  //translation failure
 
                 argument.Window.Editbox.Text = translation.text;
@@ -290,9 +290,11 @@ namespace adiIRC_DeepL_plugin_test
                 // TEST PURPOSES ONLY
                 if (reverseTranslate && reverseTranslation != null)
                     return translation.text + "|" + reverseTranslation.text;
+
+                // TEST PURPOSES ONLY
+                return translation.text;
             }
-            // TEST PURPOSES ONLY
-            return translation.text;
+            return "";
         }
 
         /// <summary>

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -534,11 +534,22 @@ namespace adiIRC_DeepL_plugin_test
                                 if (match.Groups["nickname"].Success)
                                 {
                                     string nick = match.Groups["nickname"].Value;
+
+                                    // check if repeat client
+                                    int index;
+                                    if (IsNickMonitored(nick, out index))
+                                        monitor_items[index] = null;
+
                                     monitor_items[caseNum] = new monitorItem(nick, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + nick);
                                 }
                                 else
                                 {
+                                    // check if repeat client
+                                    int index;
+                                    if (IsNickMonitored(cmdr, out index))
+                                        monitor_items[index] = null;
+
                                     monitor_items[caseNum] = new monitorItem(cmdr, cmdr, langcode: langcode);
                                     PrintDebug("Monitoring " + cmdr);
                                 }

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -470,13 +470,28 @@ namespace adiIRC_DeepL_plugin_test
                 if (item != null) adihost.ActiveIWindow.OutputText(String.Format("#{0} - Nick: {1}, Lang: {2}", index, item.nickname, item.langcode));
                 index++;
             }
+
+            string monitoredChannels = "";
             foreach (string channelName in config_items.channel_monitor_items)
             {
-                adihost.ActiveIWindow.OutputText("Monitored Channel: " + channelName);
+                monitoredChannels += channelName + ", ";
             }
+            monitoredChannels = monitoredChannels.TrimEnd(' ', ',');
+
+            string excludedLangs = "";
+            foreach (string lang in config_items.lang_no_translation)
+            {
+                excludedLangs += lang + ", ";
+            }
+            excludedLangs = excludedLangs.TrimEnd(' ', ',');
+
+            adihost.ActiveIWindow.OutputText("Native Language: " + config_items.native_lang);
+            adihost.ActiveIWindow.OutputText("Monitored Channels: " + monitoredChannels);
+            adihost.ActiveIWindow.OutputText("Excluded Languages: " + excludedLangs);
             adihost.ActiveIWindow.OutputText("AutoRemoveNick: " + config_items.removePartingNicknames);
             adihost.ActiveIWindow.OutputText("ReverseTranslate: " + reverseTranslate);
             adihost.ActiveIWindow.OutputText("Drillmode: " + drillmode);
+            adihost.ActiveIWindow.OutputText("Debugmode: " + debugmode);
         }
 
         public void deepl_help(RegisteredCommandArgs argument)

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -176,7 +176,7 @@ namespace adiIRC_DeepL_plugin_test
                     Dictionary<string, string> dict = new Dictionary<string, string>();
                     dict.Add("text", totranslate);
                     dict.Add("target_lang", lang);
-                    if(!string.IsNullOrEmpty(sourceLang)) dict.Add("source_lang", sourceLang);
+                    if (!string.IsNullOrEmpty(sourceLang)) dict.Add("source_lang", sourceLang);
                     requestMessage.Headers.TryAddWithoutValidation("Content-Type", "application/x-www-form-urlencoded");
                     requestMessage.Headers.Authorization = new AuthenticationHeaderValue("DeepL-Auth-Key", config_items.apikey);
                     requestMessage.Content = new FormUrlEncodedContent(dict);
@@ -218,7 +218,7 @@ namespace adiIRC_DeepL_plugin_test
         /// <param name="lang">Rat's language, usually EN</param>
         /// <param name="totranslate">Message to translate</param>
         /// <param name="window">Window to post message</param>
-        /// <param name="fromUser">Client's nick</param>
+        /// <param name="fromUser">User's MonitorItem</param>
         public async Task<string> deepl_translate_towindow(string lang, string totranslate, IWindow window, monitorItem fromUser) //return string for test validation purposes
         {
             deepl_translation translation;
@@ -249,6 +249,7 @@ namespace adiIRC_DeepL_plugin_test
                 fromUser.retries = 0;
             window.OutputText(fromUser.nickname + "(" + translation.detected_source_language + "): " + translation.text);
 
+            // TEST PURPOSES ONLY
             return fromUser.nickname + "(" + translation.detected_source_language + "): " + translation.text; // FOR TEST ONLY
         }
     
@@ -286,10 +287,11 @@ namespace adiIRC_DeepL_plugin_test
                     argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
                 }
 
-                // return type changd for debug and unit test purposes
+                // TEST PURPOSES ONLY
                 if (reverseTranslate && reverseTranslation != null)
                     return translation.text + "|" + reverseTranslation.text;
             }
+            // TEST PURPOSES ONLY
             return translation.text;
         }
 


### PR DESCRIPTION
Tidied up some error handling, added more comments to make differences between AdiPlugin and TestPlugin clearer.

I thought repeat clients, and multiple monitors for the same user would be a problem. But upon further consideration, it's not a problem, so the fix was removed.

Then the big thing is being able to change your native language. Auto-translations and /dl-en will now translate to the user's preferred language.