### PR TITLE
Paid API compatibility

### DIFF
--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -171,7 +171,7 @@
             {
                 HttpClientHandler handler = new HttpClientHandler();
                 HttpClient httpClient = new HttpClient(handler);
-                using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, "https://api.deepl.com/v2/translate"))
+                using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, "https://" + config_items.api_endpoint + "/v2/translate"))
                 {
                     Dictionary<string, string> dict = new Dictionary<string, string>();
                     dict.Add("text", totranslate);

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -297,14 +297,29 @@
         /// <param name="argument">language code, and message to translate</param>
         private async void deepl_any(RegisteredCommandArgs argument)
         {
-            string allarguments = argument.Command.Substring(argument.Command.IndexOf(" ") + 1);
-            string lang = allarguments.Substring(0, 2).ToUpper();
-            string totranslate = allarguments.Substring(3);
+            string[] allArgs = argument.Command.Split(new char[] { ' ' }, 3);
+            string lang, cmdr = "";
+
+            // if first arg is a number, find the case, use lang and cmdr from the case
+            int index;
+            if (int.TryParse(allArgs[1], out index) && monitor_items[index] != null)
+            {
+                lang = monitor_items[index].langcode;
+                cmdr = monitor_items[index].cmdr;
+            }
+            else
+                lang = allArgs[1];
+
+            string totranslate = allArgs[2];
             deepl_translation translation = await deepl_translate(lang, totranslate);
 
-            if (translation != null) // check for translation failure
-            {  
-                argument.Window.Editbox.Text = translation.text;
+            if (translation != null)
+            {  //translation failure
+
+                string translationText = translation.text;
+                if (!string.IsNullOrEmpty(cmdr))
+                    translationText = cmdr + ", " + translationText;
+                argument.Window.Editbox.Text = translationText;
 
                 deepl_translation reverseTranslation = null;
                 if (reverseTranslate)
@@ -521,9 +536,9 @@
             adihost.ActiveIWindow.OutputText("AdiIRC Deepl Plugin Command Reference");
             adihost.ActiveIWindow.OutputText("/dl-api <api-key> - Sets your DeepL Api key. https://www.deepl.com/en/signup/?cta=checkout");
             adihost.ActiveIWindow.OutputText("/dl-en <text> - Translates text to english");
-            adihost.ActiveIWindow.OutputText("/dl-any <langcode> <text> - Translates text to target language and places translation into active editbox");
+            adihost.ActiveIWindow.OutputText("/dl-any <langcode|caseNumber> <text> - Translates text to target language and places translation into active editbox");
             adihost.ActiveIWindow.OutputText("/dl-mon <nickname> - Translates every message made by <nickname> to your native language");
-            adihost.ActiveIWindow.OutputText("/dl-rm <nickname>|<caseNumber> - Removes a single nickname or case number from the monitor list");
+            adihost.ActiveIWindow.OutputText("/dl-rm <nickname|caseNumber> - Removes a single nickname or case number from the monitor list");
             adihost.ActiveIWindow.OutputText("/dl-mecha - Starts monitoring for Fuel Rats cases announced by MechaSqueak in the active channel");
             adihost.ActiveIWindow.OutputText("/dl-clear - Clears the list of nicks to monitor for translations. Also disables case monitoring");
             adihost.ActiveIWindow.OutputText("/dl-set <option> - Configures certain behavious of the plugin");

--- a/AdiIRCPlugin.csproj
+++ b/AdiIRCPlugin.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{9BFBD04C-63BE-4870-8B95-290837FF8FA8}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>adiIRC_DeepL</AssemblyName>

--- a/AdiIRCPlugin.csproj
+++ b/AdiIRCPlugin.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{9BFBD04C-63BE-4870-8B95-290837FF8FA8}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>adiIRC_DeepL</AssemblyName>

--- a/README.md
+++ b/README.md
@@ -73,15 +73,19 @@ This will translate a message from any DeepL supported language to user's native
 --  
 **/dl-any**
 ```
-/dl-any <langcode> <message>
+/dl-any <langcode|caseNumber> <message>
 Args:
  - langcode: Two letter language code for target translation
+ - caseNumber: Integer that represents a FuelRats case
  - message: Message to translate into target language
 Example usage:
 /dl-any FR This is a test
+/dl-any 3 This is a test
 ```
 
 Translates any language into a target language. Usually this will be your native language into a non-native language. "/dl-set reverseTranslate" can be used to enable this function to translate the resulting message back into user's native language for inspection purposes.
+
+When using a case number, the plugin will find the client's language code, and also prepend the client's name to the resulting message.
 
 --  
 **/dl-mon**

--- a/TestDriver.cs
+++ b/TestDriver.cs
@@ -199,8 +199,11 @@ namespace adiIRC_DeepL_plugin_test
             {
                 Console.WriteLine("\n==== Good and Bad Lang Code ====");
                 string success = await testPlugin.deepl_any(new RegisteredCommandArgs("_ FR This is a test.", fuelratsChan));
+
+                testPlugin.monitor_items[5].langcode = "FR";
+                string caseNum = await testPlugin.deepl_any(new RegisteredCommandArgs("_ 5 This is a test.", fuelratsChan));
                 string failure = await testPlugin.deepl_any(new RegisteredCommandArgs("_ XY This is a test.", fuelratsChan));
-                if (success.Equals("Il s'agit d'un test.") && String.IsNullOrEmpty(failure)) testResult = true;
+                if (success.Equals("Il s'agit d'un test.") && caseNum.Equals("Delryn, Il s'agit d'un test.") && String.IsNullOrEmpty(failure)) testResult = true;
                 else testResult = false;
                 PrintTestResult("Good/Bad Lang Code", testResult);
             }

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -304,15 +304,29 @@ namespace adiIRC_DeepL_plugin_test
         /// <param name="argument">language code, and message to translate</param>
         public async Task<string> deepl_any(RegisteredCommandArgs argument) // for testing, return Task<string> so we can await the completion of this function and validate output
         {
-            string allarguments = argument.Command.Substring(argument.Command.IndexOf(" ") + 1);
-            string lang = allarguments.Substring(0, 2).ToUpper();
-            string totranslate = allarguments.Substring(3);
+            string[] allArgs = argument.Command.Split(new char[] {' '}, 3);
+            string lang, cmdr = "";
+
+            // if first arg is a number, find the case, use lang and cmdr from the case
+            int index;
+            if (int.TryParse(allArgs[1], out index) && monitor_items[index] != null)
+            {
+                lang = monitor_items[index].langcode;
+                cmdr = monitor_items[index].cmdr;
+            }
+            else
+                lang = allArgs[1];
+
+            string totranslate = allArgs[2];
             deepl_translation translation = await deepl_translate(lang, totranslate);
 
             if (translation != null)
             {  //translation failure
 
-                argument.Window.Editbox.Text = translation.text;
+                string translationText = translation.text;
+                if (!string.IsNullOrEmpty(cmdr))
+                    translationText = cmdr + ", " + translationText;
+                argument.Window.Editbox.Text = translationText;
 
                 deepl_translation reverseTranslation = null;
                 if (reverseTranslate)
@@ -326,7 +340,7 @@ namespace adiIRC_DeepL_plugin_test
                     return translation.text + "|" + reverseTranslation.text;
 
                 // TEST PURPOSES ONLY
-                return translation.text;
+                return translationText;
             }
             return "";
         }
@@ -532,9 +546,9 @@ namespace adiIRC_DeepL_plugin_test
             adihost.ActiveIWindow.OutputText("AdiIRC Deepl Plugin Command Reference");
             adihost.ActiveIWindow.OutputText("/dl-api <api-key> - Sets your DeepL Api key. https://www.deepl.com/en/signup/?cta=checkout");
             adihost.ActiveIWindow.OutputText("/dl-en <text> - Translates text to english");
-            adihost.ActiveIWindow.OutputText("/dl-any <langcode> <text> - Translates text to target language and places translation into active editbox");
+            adihost.ActiveIWindow.OutputText("/dl-any <langcode|caseNumber> <text> - Translates text to target language and places translation into active editbox");
             adihost.ActiveIWindow.OutputText("/dl-mon <nickname> - Translates every message made by <nickname> to your native language");
-            adihost.ActiveIWindow.OutputText("/dl-rm <nickname>|<caseNumber> - Removes a single nickname or case number from the monitor list");
+            adihost.ActiveIWindow.OutputText("/dl-rm <nickname|caseNumber> - Removes a single nickname or case number from the monitor list");
             adihost.ActiveIWindow.OutputText("/dl-mecha - Starts monitoring for Fuel Rats cases announced by MechaSqueak in the active channel");
             adihost.ActiveIWindow.OutputText("/dl-clear - Clears the list of nicks to monitor for translations. Also disables case monitoring");
             adihost.ActiveIWindow.OutputText("/dl-set <option> - Configures certain behavious of the plugin");


### PR DESCRIPTION
Currently the plugin is hardcoded to use the free-api. This change will detect and switch to the paid API URL if necessary. The implementation could be a bit better, but this is a decent quickfix for the few people that use the paid API.