### PR TITLE
'reverseTranslate' setting will be remembered between restarts

### DIFF
--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -51,7 +51,7 @@
     {
         public string apikey, native_lang, api_endpoint;    // Api Key sent with all deepl calls
         public List<string> lang_no_translation;  // List of language codes skip when adding new nicks to monitoring
-        public bool removePartingNicknames; // Whether or not to autoremove monitored nicknames that leave the channel.
+        public bool removePartingNicknames, reverseTranslate; // Whether or not to autoremove monitored nicknames that leave the channel.
         public List<string> channel_monitor_items;
 
         public deepl_config_items()
@@ -62,6 +62,7 @@
             lang_no_translation = new List<string>();
             channel_monitor_items = new List<string>();
             api_endpoint = "api-free.deepl.com";
+            reverseTranslate = false;
         }
     }
 
@@ -81,7 +82,7 @@
         private string deepl_config_file;
         private deepl_config_items config_items;
         private List<monitorItem> monitor_items;
-        private static bool drillmode = false, debugmode = false, reverseTranslate = false;
+        private static bool drillmode = false, debugmode = false;
         private const string NO_LANG = "ZZ"; // AKA: Translate as an unknown language
         private ITools tools;
 
@@ -195,10 +196,9 @@
                             return null;
                     }
 
-                    deepl_json_response jsonResponse = JsonConvert.DeserializeObject<deepl_json_response>(responseContent);
                     try
                     {
-                        jsonResponse = JsonConvert.DeserializeObject<deepl_json_response>(responseContent);
+                        deepl_json_response jsonResponse = JsonConvert.DeserializeObject<deepl_json_response>(responseContent);
                         if (response.IsSuccessStatusCode)
                         {
                             // If the sourceLang was incorrect, toTranslate and the translation will be the same, re-run the translation with no langcode
@@ -220,18 +220,9 @@
                     }
                     catch (Exception e)
                     {
-                        adihost.ActiveIWindow.OutputText("DeepL Plugin: Failed to parse DeepL API Response. See: " + adihost.ConfigFolder + "\\deepl_debug.log");
-                        try
-                        {
-                            System.IO.File.WriteAllText(adihost.ConfigFolder + "deepl_debug.log", DateTime.Now.ToString() + String.Format(" - Translation text: {0} | Source Lang: {1} | Target Lang: {2}", totranslate, sourceLang, lang));
-                            System.IO.File.WriteAllText(adihost.ConfigFolder + "deepl_debug.log", DateTime.Now.ToString() + " - " + responseContent);
-                            System.IO.File.WriteAllText(adihost.ConfigFolder + "deepl_debug.log", DateTime.Now.ToString() + " - " + e.Message);
-                        }
-                        catch (Exception f)
-                        {
-                            adihost.ActiveIWindow.OutputText("DeepL Plugin: Failed to write to debug log.");
-                            adihost.ActiveIWindow.OutputText(f.ToString());
-                        }
+                        adihost.ActiveIWindow.OutputText("DeepL Plugin: Failed to parse translation response. General error. See /rawlog");
+                        tools.Debug(e.ToString());
+                        tools.Debug("HTTP Response: " + responseContent);
                     }
                 }
             }
@@ -323,7 +314,7 @@
                 argument.Window.Editbox.Text = translationText;
 
                 deepl_translation reverseTranslation = null;
-                if (reverseTranslate)
+                if (config_items.reverseTranslate)
                 {
                     reverseTranslation = await deepl_translate(config_items.native_lang, translation.text, lang);
                     argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
@@ -465,9 +456,9 @@
 
             if (allarguments[1].Equals("reverseTranslate"))
             {
-                reverseTranslate = !reverseTranslate;
+                config_items.reverseTranslate = !config_items.reverseTranslate;
                 // print drillmode state after switch
-                if (reverseTranslate) adihost.ActiveIWindow.OutputText("/dl-any will be reverse translated.");
+                if (config_items.reverseTranslate) adihost.ActiveIWindow.OutputText("/dl-any will be reverse translated.");
                 else adihost.ActiveIWindow.OutputText("Reverse Translation Disabled.");
 
                 save_config_items();
@@ -558,7 +549,7 @@
             adihost.ActiveIWindow.OutputText("Monitored Channels: " + monitoredChannels);
             adihost.ActiveIWindow.OutputText("Excluded Languages: " + excludedLangs);
             adihost.ActiveIWindow.OutputText("AutoRemoveNick: " + config_items.removePartingNicknames);
-            adihost.ActiveIWindow.OutputText("ReverseTranslate: " + reverseTranslate);
+            adihost.ActiveIWindow.OutputText("ReverseTranslate: " + config_items.reverseTranslate);
             adihost.ActiveIWindow.OutputText("Drillmode: " + drillmode);
             adihost.ActiveIWindow.OutputText("Debugmode: " + debugmode);
         }

--- a/AdiIRCPlugin.cs
+++ b/AdiIRCPlugin.cs
@@ -74,7 +74,7 @@
 
         public string PluginAuthor { get { return "Velica Foriana"; } }
 
-        public string PluginVersion { get { return "1.3"; } }
+        public string PluginVersion { get { return "1.3.3d"; } }
 
         public string PluginEmail { get { return "velicaforiana@******"; } }
 
@@ -599,7 +599,7 @@
                     // Identify Ratsignal or Drillsignal
                     PrintDebug("Matched Channel");
                     string stripped = Regex.Replace(message.Message, @"(\x03(?:\d{1,2}(?:,\d{1,2})?)?)|\x02|\x0F|\x16|\x1F", "");
-                    Regex regex = new Regex(@"(RAT|DRILL)SIGNAL Case #(?<caseNum>\d+) (PC)? ?(?<platform>ODY|HOR|LEG|Playstation|Xbox).*CMDR (?<cmdr>.+?) (\(Offline\) )?– System: .* Language: .+ \((?<langcode>[a-z]{2})(?:-\w{2,3})?\)(?: – Nick: (?<nickname>[\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?");
+                    Regex regex = new Regex(@"(RAT|DRILL)SIGNAL Case #(?<caseNum>\d+) (PC)? ?(?<platform>ODY|HOR|LEG|Playstation|Xbox).*CMDR (?<cmdr>.+?) (\(.*\) )?– System: .* Language: .+ \((?<langcode>[a-z]{2})(?:-\w{2,3})?\)(?: – Nick: (?<nickname>[\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?");
                     Match match = regex.Match(stripped);
                     if (match.Success)
                     {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyVersion("1.3.4")]
+[assembly: AssemblyFileVersion("1.3.4")]

--- a/TestDriver.cs
+++ b/TestDriver.cs
@@ -69,7 +69,7 @@ namespace adiIRC_DeepL_plugin_test
 
             // Test Xbox RSignal with (Offline) by cmdr name
             Console.WriteLine("\n==== Autodetect XB Offline Case ====");
-            rsig = "RATSIGNAL Case #7 Xbox – CMDR Delrat (Offline) – System: \"LHS 2191\" (Invalid system name) – Language: English (United States) (en-US) (XB_SIGNAL)";
+            rsig = "RATSIGNAL Case #7 Playstation – CMDR Delrat (Unavailable) – System: \"PRUA DRYOAE DB - Z A27 - 1\" (2,175.3 LY \"East\" of Sol) – Language: Spanish (Spain) (es-ES) (PS_SIGNAL)";
             // Create example mecha rsig message
             ratsignal = new ChannelNormalMessageArgs(rsig, fuelratsChan);
             ratsignal.User.Nick = "MechaSqueak[BOT]";
@@ -79,7 +79,7 @@ namespace adiIRC_DeepL_plugin_test
             if (testPlugin.monitor_items[7] != null &&
                 testPlugin.monitor_items[7].nickname.Equals("Delrat")) testResult = true;
             else testResult = false;
-            PrintTestResult("XBox Rsig Autodetect", testResult);
+            PrintTestResult("PS Rsig Autodetect", testResult);
 
 
 

--- a/TestDriver.cs
+++ b/TestDriver.cs
@@ -41,6 +41,7 @@ namespace adiIRC_DeepL_plugin_test
             }
 
             bool testResult = false;
+
             bool testAPI = true; // flip this switch to test API calls, keep off to save API usage
             testPlugin.deepl_set(new RegisteredCommandArgs("_ native EN", fuelratsChan));
 
@@ -208,7 +209,7 @@ namespace adiIRC_DeepL_plugin_test
             if (testAPI)
             {
                 Console.WriteLine("\n==== Reverse Translation ====");
-                if (!adiIRC_DeepL_plugin.reverseTranslate) testPlugin.deepl_set(new RegisteredCommandArgs("_ reverseTranslate", fuelratsChan));
+                if (!testPlugin.config_items.reverseTranslate) testPlugin.deepl_set(new RegisteredCommandArgs("_ reverseTranslate", fuelratsChan));
                 string translation = await testPlugin.deepl_any(new RegisteredCommandArgs("_ FR This is a test.", fuelratsChan));
                 if (translation.Equals("Il s'agit d'un test.|This is a test.")) testResult = true;
                 else testResult = false;

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -55,7 +55,7 @@ namespace adiIRC_DeepL_plugin_test
     {
         public string apikey, native_lang, api_endpoint;    // Api Key sent with all deepl calls
         public List<string> lang_no_translation;  // List of language codes skip when adding new nicks to monitoring
-        public bool removePartingNicknames; // Whether or not to autoremove monitored nicknames that leave the channel.
+        public bool removePartingNicknames, reverseTranslate; // Whether or not to autoremove monitored nicknames that leave the channel.
         public List<string> channel_monitor_items;
 
         public deepl_config_items()
@@ -66,6 +66,7 @@ namespace adiIRC_DeepL_plugin_test
             lang_no_translation = new List<string>();
             channel_monitor_items = new List<string>();
             api_endpoint = "api-free.deepl.com";
+            reverseTranslate = false;
         }
     }
 
@@ -85,7 +86,7 @@ namespace adiIRC_DeepL_plugin_test
         private string deepl_config_file;
         public deepl_config_items config_items;
         public List<monitorItem> monitor_items;
-        public static bool drillmode = false, debugmode = false, reverseTranslate = false;
+        public static bool drillmode = false, debugmode = false;
         public const string NO_LANG = "ZZ";
 
         /// <summary>
@@ -331,14 +332,14 @@ namespace adiIRC_DeepL_plugin_test
 
                 //do a reverse translation back into user's native language
                 deepl_translation reverseTranslation = null;
-                if (reverseTranslate)
+                if (config_items.reverseTranslate)
                 {
                     reverseTranslation = await deepl_translate(config_items.native_lang, translation.text, lang);
                     argument.Window.OutputText("Reverse Translation: " + reverseTranslation.text);
                 }
 
                 // TEST PURPOSES ONLY
-                if (reverseTranslate && reverseTranslation != null)
+                if (config_items.reverseTranslate && reverseTranslation != null)
                     return translation.text + "|" + reverseTranslation.text;
 
                 // TEST PURPOSES ONLY
@@ -474,9 +475,9 @@ namespace adiIRC_DeepL_plugin_test
 
             if (allarguments[1].Equals("reverseTranslate"))
             {
-                reverseTranslate = !reverseTranslate;
+                config_items.reverseTranslate = !config_items.reverseTranslate;
                 // print drillmode state after switch
-                if (reverseTranslate) adihost.ActiveIWindow.OutputText("/dl-any will be reverse translated.");
+                if (config_items.reverseTranslate) adihost.ActiveIWindow.OutputText("/dl-any will be reverse translated.");
                 else adihost.ActiveIWindow.OutputText("Reverse Translation Disabled.");
 
                 save_config_items();
@@ -567,7 +568,7 @@ namespace adiIRC_DeepL_plugin_test
             adihost.ActiveIWindow.OutputText("Monitored Channels: " + monitoredChannels);
             adihost.ActiveIWindow.OutputText("Excluded Languages: " + excludedLangs);
             adihost.ActiveIWindow.OutputText("AutoRemoveNick: " + config_items.removePartingNicknames);
-            adihost.ActiveIWindow.OutputText("ReverseTranslate: " + reverseTranslate);
+            adihost.ActiveIWindow.OutputText("reverseTranslate: " + config_items.reverseTranslate);
             adihost.ActiveIWindow.OutputText("Drillmode: " + drillmode);
             adihost.ActiveIWindow.OutputText("Debugmode: " + debugmode);
         }

--- a/TestPlugin.cs
+++ b/TestPlugin.cs
@@ -618,7 +618,7 @@ namespace adiIRC_DeepL_plugin_test
                     // Identify Ratsignal or Drillsignal
                     PrintDebug("Matched Channel");
                     string stripped = Regex.Replace(message.Message, @"(\x03(?:\d{1,2}(?:,\d{1,2})?)?)|\x02|\x0F|\x16|\x1F", "");
-                    Regex regex = new Regex(@"(RAT|DRILL)SIGNAL Case #(?<caseNum>\d+) (PC)? ?(?<platform>ODY|HOR|LEG|Playstation|Xbox).*CMDR (?<cmdr>.+?) (\(Offline\) )?– System: .* Language: .+ \((?<langcode>[a-z]{2})(?:-\w{2,3})?\)(?: – Nick: (?<nickname>[\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?");
+                    Regex regex = new Regex(@"(RAT|DRILL)SIGNAL Case #(?<caseNum>\d+) (PC)? ?(?<platform>ODY|HOR|LEG|Playstation|Xbox).*CMDR (?<cmdr>.+?) (\(.*\) )?– System: .* Language: .+ \((?<langcode>[a-z]{2})(?:-\w{2,3})?\)(?: – Nick: (?<nickname>[\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?");
                     Match match = regex.Match(stripped);
                     if (match.Success)
                     {


### PR DESCRIPTION
Now saves the 'reverseTranslate' option to the config file (I always keep this on).

Also, writes more information to the /rawlog rather than a text log file. Text log file is reserved for complete failures.